### PR TITLE
Historian CSV improvements

### DIFF
--- a/tclab/historian.py
+++ b/tclab/historian.py
@@ -218,10 +218,40 @@ class Historian(object):
             self.db.close()
 
     def to_csv(self, filename):
-        """Output contents of log file to CSV"""
-        import csv
+        """Output contents of log file to CSV
 
-        with open(filename, 'w') as f:
+        :param filename: str, pathlib.Path, file handle or file-like object
+                into which the CSV data should be written. Files and
+                file-like objects should be opened in text mode and files
+                should be opened with the option `newline=""` to prevent
+                extra new lines being inserted.
+
+        Examples::
+
+        >>> h = Historian(lab.sources)
+        >>> # run the experiment
+        >>>
+        >>> h.to_csv("myfile.csv")
+        >>>
+        >>> with open("myfile2.csv", "w", newline="") as fh:
+        ...     h.to_csv(fh)
+        >>>
+        >>> s = io.StringIO()
+        >>> h.to_csv(s)
+        """
+        import contextlib
+        import csv
+        import pathlib
+
+        @contextlib.contextmanager
+        def open_if_filename(file_or_filename):
+            if isinstance(file_or_filename, (str, pathlib.Path)):
+                with open(file_or_filename, 'w', newline='') as fh:
+                    yield fh
+            else:
+                yield file_or_filename
+
+        with open_if_filename(filename) as f:
             writer = csv.writer(f)
             writer.writerow(self.columns)
             writer.writerows(self.log)


### PR DESCRIPTION
This patch adds three simple improvements to the `to_csv()` method of the Historian:

- open the file in `to_csv()` with `newline=""` to prevent lots of blank lines in the output. See https://docs.python.org/3/library/csv.html#csv.writer
- allow `to_csv()` to also accept file-handles and file-like objects so that data can be written to `StringIO` etc
- expand docstring to `to_csv()`